### PR TITLE
Refactor "About Me" Section for Portfolio to Reflect Updated Experience and Leadership Role

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,18 +251,17 @@
                             <h2>
                                 Hello, I am <span>Christopher Lunetta</span>
                             </h2>
-                            <h4>Full Stack Web Developer</h4>
+                            <h4>Full Stack Software Engineer with Leadership Experience</h4>
                             <p>
-                                After years of working in the Entertainment and
-                                Transportation industry I decided to take the
-                                leap into a new career path. I have always had a
-                                knack for figuring out how things work and using
-                                that knowledge to find new ways to solve
-                                problems. Software Development was the perfect
-                                direction for me to go with my problem solving
-                                abilities, team driven leadership skills and a
-                                love for continued learning.
+                                I'm a full stack software engineer with almost 4 years of hands-on experience delivering scalable, cloud-native solutions across healthcare, finance, and other complex industries. I specialize in C#, .NET, Blazor, Azure Functions, SQL Server, and React—building robust web applications with a focus on performance, maintainability, and user experience.
                             </p>
+                            <p>
+                                While at Insight, I stepped into a team lead role focused on people-first leadership. I served as a connector between our practice manager and engineers across multiple projects, offering mentorship, promoting work-life balance, and creating space for open, supportive communication. That experience shaped how I approach collaboration—with empathy, clarity, and purpose.
+                            </p>
+                            <p>
+                                I'm currently seeking new opportunities where I can contribute to meaningful products, grow alongside great teams, and continue mentoring others. I'm open to remote roles or positions in Middle Tennessee.
+                            </p>
+                            
 
                             <h5>Techonlogies</h5>
 

--- a/index.html
+++ b/index.html
@@ -259,7 +259,7 @@
                                 While at Insight, I stepped into a team lead role focused on people-first leadership. I served as a connector between our practice manager and engineers across multiple projects, offering mentorship, promoting work-life balance, and creating space for open, supportive communication. That experience shaped how I approach collaboration—with empathy, clarity, and purpose.
                             </p>
                             <p>
-                                I'm currently seeking new opportunities where I can contribute to meaningful products, grow alongside great teams, and continue mentoring others. I'm open to remote roles or positions in Middle Tennessee.
+                                I’m currently seeking new opportunities where I can contribute to meaningful products, grow with collaborative teams, and continue mentoring others. I'm open to remote roles anywhere, and hybrid or in-person roles based in Middle Tennessee.
                             </p>
                             
 


### PR DESCRIPTION
### Summary
This PR updates the "About Me" section on the portfolio site to more accurately reflect my professional background, including nearly 4 years of software engineering experience, key technologies in my stack, and recent leadership responsibilities at Insight.

### Changes
- Rewrote the introduction to better showcase core competencies and industry experience
- Clarified the nature of my team lead role as people-first and mentorship-focused
- Updated the tech stack reference to include C#, .NET, Blazor, Azure, React, and SQL Server
- Added a clear statement of current availability and geographic preferences

### Purpose
Improve the relevance, clarity, and impact of the "About Me" section for recruiters, collaborators, and technical stakeholders who visit the portfolio.

### Acceptance Criteria
- [x] Language is professional, accurate, and concise
- [x] Experience and leadership roles are clearly described
- [x] Technology stack is aligned with current capabilities
- [x] Section supports overall goals of visibility and approachability for potential employers